### PR TITLE
windows pathing fix

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -18,6 +18,14 @@ const data = Buffer.from(dataBuf)
 async function start () {
   let fn
   try {
+    if(typeof process !== "undefined"){
+      //reused the error code.
+      const err = new Error()
+      err.code = 'ERR_MODULE_NOT_FOUND';
+      throw err;
+    }
+    //this will not universally work on all node.js instances and use-cases.
+    //better to hand it over to require when using node.js
     fn = (await realImport(workerData.filename)).default
   } catch (error) {
     // A yarn user that tries to start a ThreadStream for an external module
@@ -30,7 +38,7 @@ async function start () {
     // The error codes may change based on the node.js version (ENOTDIR > 12, ERR_MODULE_NOT_FOUND <= 12 )
     if ((error.code === 'ENOTDIR' || error.code === 'ERR_MODULE_NOT_FOUND') &&
      workerData.filename.startsWith('file://')) {
-      fn = realRequire(workerData.filename.replace('file://', ''))
+      fn = realRequire(workerData.filename.replace(workerData.filename[9] === ":" ? 'file:///' : 'file://', ''))
     } else {
       throw error
     }


### PR DESCRIPTION
import will not universally work on all node.js use-cases like pkg for example. I made fix to handover the module loading to require in node.js for better compatibility.

when removing the 'file://' from path, in windows, it will leave a leading '/' in the path that will make the worker module loading fail.